### PR TITLE
Move PlayerControllerB patches to PlayerControllerBPatch.cs

### DIFF
--- a/Class1.cs
+++ b/Class1.cs
@@ -126,7 +126,7 @@ namespace LethalCompanyTestMod
             Instance = this;
             mls = BepInEx.Logging.Logger.CreateLogSource("GameMaster");
             // Plugin startup logic
-            mls.LogInfo("Loaded GameMaster. Patching.");
+            mls.LogInfo($"Loaded {modGUID}. Patching.");
             harmony.PatchAll(typeof(TestMod));
             mls = Logger;
             enemyRaritys = new Dictionary<SpawnableEnemyWithRarity, int>();

--- a/Class1.cs
+++ b/Class1.cs
@@ -391,62 +391,6 @@ namespace LethalCompanyTestMod
             //return speedHack;
         }
 
-        [HarmonyPatch(typeof(PlayerControllerB), "Update")]
-        [HarmonyPrefix]
-        static void patchControllerUpdate()
-        {
-            myGUI.guiIsHost = isHost;
-            Instance.UpdateCFGVarsFromGUI();
-        }
-
-        [HarmonyPatch(typeof(PlayerControllerB), "Start")]
-        [HarmonyPrefix]
-        static void getNightVision(ref PlayerControllerB __instance)
-        {
-            playerRef = __instance;
-            nightVision = playerRef.nightVision.enabled;
-            // store nightvision values
-            nightVisionIntensity = playerRef.nightVision.intensity;
-            nightVisionColor = playerRef.nightVision.color;
-            nightVisionRange = playerRef.nightVision.range;
-
-            playerRef.nightVision.color = UnityEngine.Color.green;
-            playerRef.nightVision.intensity = 1000f;
-            playerRef.nightVision.range = 10000f;
-        }
-
-        [HarmonyPatch(typeof(PlayerControllerB), "SetNightVisionEnabled")]
-        [HarmonyPostfix]
-        static void updateNightVision()
-        {
-            //instead of enabling/disabling nightvision, set the variables
-
-            if (nightVision)
-            {
-                playerRef.nightVision.color = UnityEngine.Color.green;
-                playerRef.nightVision.intensity = 1000f;
-                playerRef.nightVision.range = 10000f;
-            }
-            else
-            {
-                playerRef.nightVision.color = nightVisionColor;
-                playerRef.nightVision.intensity = nightVisionIntensity;
-                playerRef.nightVision.range = nightVisionRange;
-            }
-
-            // should always be on
-            playerRef.nightVision.enabled = true;
-        }
-
-
-        [HarmonyPatch(typeof(PlayerControllerB), "AllowPlayerDeath")]
-        [HarmonyPrefix]
-        static bool OverrideDeath()
-        {
-            if (!isHost) { return true; }
-            return !enableGod;
-        }
-
         [HarmonyPatch(typeof(Terminal), nameof(Terminal.RunTerminalEvents))]
         [HarmonyPostfix]
         static void NeverLoseCredits(ref int ___groupCredits)
@@ -1286,14 +1230,6 @@ namespace LethalCompanyTestMod
             if (EnableAIModifiers.Value && isHost) { ___noPlayersToChaseTimer = JesterResetTimer.Value; }
             
 
-        }
-
-        [HarmonyPatch(typeof(PlayerControllerB), "Update")]
-        [HarmonyPostfix]
-        static void InfiniteSprint(ref float ___sprintMeter)
-        {
-            
-            if (EnableInfiniteSprint.Value && isHost) { Mathf.Clamp(___sprintMeter += 0.02f, 0f, 1f); }
         }
 
         [HarmonyPatch(typeof(CrawlerAI), nameof(CrawlerAI.HitEnemy))]

--- a/Class1.cs
+++ b/Class1.cs
@@ -66,7 +66,7 @@ namespace LethalCompanyTestMod
 
         private static ConfigEntry<bool> HideCommandMessages;
         private static ConfigEntry<bool> HideEnemySpawnMessages;
-        private static ConfigEntry<bool> EnableInfiniteSprint;
+        internal static ConfigEntry<bool> EnableInfiniteSprint;
         private static ConfigEntry<bool> EnableInfiniteCredits;
         private static ConfigEntry<bool> EnableInfiniteDeadline;
         private static ConfigEntry<int> XPChange;
@@ -106,20 +106,20 @@ namespace LethalCompanyTestMod
         // plan for more in the future
         private static SpawnableEnemyWithRarity jesterRef;
 
-        private static GUILoader myGUI;
+        internal static GUILoader myGUI;
         private static bool noClipEnabled;
-        private static bool enableGod;
-        private static bool nightVision;
-        private static PlayerControllerB playerRef;
+        internal static bool enableGod;
+        internal static bool nightVision;
+        internal static PlayerControllerB playerRef;
         private static bool speedHack;
-        private static float nightVisionIntensity;
-        private static float nightVisionRange;
-        private static UnityEngine.Color nightVisionColor;
+        internal static float nightVisionIntensity;
+        internal static float nightVisionRange;
+        internal static UnityEngine.Color nightVisionColor;
 
         private static bool hasGUISynced = false;
-        private static bool isHost;
+        internal static bool isHost;
 
-        private static TestMod Instance;
+        internal static TestMod Instance;
 
         void Awake()
         {
@@ -196,7 +196,7 @@ namespace LethalCompanyTestMod
             hasGUISynced = true;
         }
 
-        void UpdateCFGVarsFromGUI()
+        internal void UpdateCFGVarsFromGUI()
         {
             if(!hasGUISynced) { setGUIVars(); }
             // bools

--- a/LethalCompanyTestMod.csproj
+++ b/LethalCompanyTestMod.csproj
@@ -79,6 +79,7 @@
   <ItemGroup>
     <Compile Include="Class1.cs" />
     <Compile Include="GUILoader.cs" />
+    <Compile Include="Patches\PlayerControllerBPatch.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Patches/PlayerControllerBPatch.cs
+++ b/Patches/PlayerControllerBPatch.cs
@@ -1,0 +1,69 @@
+namespace LethalCompanyTestMod.Patches
+{
+    [HarmonyPatch(typeof(PlayerControllerB))]
+    public class PlayerControllerBPatch
+    {
+        [HarmonyPatch("Update")]
+        [HarmonyPrefix]
+        static void patchControllerUpdate()
+        {
+            TestMod.myGUI.guiIsHost = TestMod.isHost;
+            TestMod.Instance.UpdateCFGVarsFromGUI();
+        }
+
+        [HarmonyPatch("Start")]
+        [HarmonyPrefix]
+        static void getNightVision(ref PlayerControllerB __instance)
+        {
+            TestMod.playerRef = __instance;
+            TestMod.nightVision = TestMod.playerRef.nightVision.enabled;
+            // store nightvision values
+            TestMod.nightVisionIntensity = TestMod.playerRef.nightVision.intensity;
+            TestMod.nightVisionColor = TestMod.playerRef.nightVision.color;
+            TestMod.nightVisionRange = TestMod.playerRef.nightVision.range;
+
+            TestMod.playerRef.nightVision.color = UnityEngine.Color.green;
+            TestMod.playerRef.nightVision.intensity = 1000f;
+            TestMod.playerRef.nightVision.range = 10000f;
+        }
+
+        [HarmonyPatch("SetNightVisionEnabled")]
+        [HarmonyPostfix]
+        static void updateNightVision()
+        {
+            //instead of enabling/disabling nightvision, set the variables
+
+            if (TestMod.nightVision)
+            {
+                TestMod.playerRef.nightVision.color = UnityEngine.Color.green;
+                TestMod.playerRef.nightVision.intensity = 1000f;
+                TestMod.playerRef.nightVision.range = 10000f;
+            }
+            else
+            {
+                TestMod.playerRef.nightVision.color = TestMod.nightVisionColor;
+                TestMod.playerRef.nightVision.intensity = TestMod.nightVisionIntensity;
+                TestMod.playerRef.nightVision.range = TestMod.nightVisionRange;
+            }
+
+            // should always be on
+            TestMod.playerRef.nightVision.enabled = true;
+        }
+        
+        [HarmonyPatch("AllowPlayerDeath")]
+        [HarmonyPrefix]
+        static bool OverrideDeath()
+        {
+            if (!TestMod.isHost) { return true; }
+            return !TestMod.enableGod;
+        }
+
+        [HarmonyPatch("Update")]
+        [HarmonyPostfix]
+        static void InfiniteSprint(ref float ___sprintMeter)
+        {
+            
+            if (TestMod.EnableInfiniteSprint.Value && TestMod.isHost) { Mathf.Clamp(___sprintMeter += 0.02f, 0f, 1f); }
+        }
+    }
+}


### PR DESCRIPTION
A simple example refactoring that moves patches that target PlayerControllerB to PlayerControllerBPatch.cs.

It also performs a tiny improvement to show the usage of a GUID instead of a hardcoded plugin name in your startup logging.